### PR TITLE
Should be able to set value for key to nil via subscript

### DIFF
--- a/OrderedDictionary/OrderedDictionary.m
+++ b/OrderedDictionary/OrderedDictionary.m
@@ -480,7 +480,7 @@
 
 - (void)setObject:(id)object forKeyedSubscript:(id)key
 {
-    [self setObject:object forKey:key];
+    [self setValue:object forKey:key];
 }
 
 @end


### PR DESCRIPTION
Allows you to remove a key by setting to nil: `dict[@"key"] = nil;`